### PR TITLE
Add training ID

### DIFF
--- a/helm/index.json
+++ b/helm/index.json
@@ -57,6 +57,7 @@
     "dashboards": [{"name": "Display 80", "port": 80}, {"name": "Display 8080", "port": 8080}]    
   },
   "backend": {
+    "trainingid": "kubeadm-cluster2-running",
     "imageid": "kubernetes-cluster-running"
   }
 }

--- a/kubernetes/index.json
+++ b/kubernetes/index.json
@@ -42,6 +42,7 @@
     "dashboards": [{"name": "Display 80", "port": 80}, {"name": "Display 8080", "port": 8080}]
   },
   "backend": {
+    "trainingid": "kubeadm-cluster2-running",
     "imageid": "kubernetes-cluster-running"
   }
 }


### PR DESCRIPTION
Temporary Workaround for Katacoda. This should pickup the correct training environment.